### PR TITLE
Replace parse5 with custom fragment parser (Fix #6)

### DIFF
--- a/customParse.js
+++ b/customParse.js
@@ -1,0 +1,135 @@
+
+import * as types from "babel-types";
+
+import parseFragment from "./parseScriptFragment.js";
+
+const startScript = /<script[^>]*>/im;
+const endScript = /<\/script\s*>/im;
+// https://stackoverflow.com/questions/5034781/js-regex-to-split-by-line#comment5633979_5035005
+const newLines = /\r\n|[\n\v\f\r\x85\u2028\u2029]/;
+
+function getType (tag) {
+  const fragment = parseFragment(tag);
+
+  if (fragment) {
+      const type = fragment.attributes.type;
+
+      return type ? type.toLowerCase() : null;
+  }
+
+  return null;
+}
+
+function getCandidateScriptLocations(source, index) {
+  const i = index || 0;
+  const str = source.substring(i);
+
+  const startMatch = startScript.exec(str);
+  if (startMatch) {
+    const startsAt = startMatch.index + startMatch[0].length;
+    const afterStart = str.substring(startsAt);
+    const endMatch = endScript.exec(afterStart);
+    if (endMatch) {
+      const locLength = endMatch.index;
+      const locIndex = i + startsAt;
+      const endIndex = locIndex + locLength + endMatch[0].length;
+
+      // extract the complete tag (incl start and end tags and content). if the
+      // type is invalid (= not JS), skip this tag and continue
+      const tag = source.substring(i + startMatch.index, endIndex);
+      const type = getType(tag);
+      if (type && (type !== "javascript" && type !== "text/javascript")) {
+        return getCandidateScriptLocations(source, endIndex);
+      }
+
+      return [
+        adjustForLineAndColumn(source, {
+          index: locIndex,
+          length: locLength,
+          source: source.substring(locIndex, locIndex + locLength)
+        }),
+        ...getCandidateScriptLocations(source, endIndex)
+      ];
+    }
+  }
+
+  return [];
+}
+
+function parseScripts(locations, parser) {
+  return locations.map(parser);
+}
+
+function generateWhitespace(length) {
+  return Array.from(new Array(length + 1)).join(" ");
+}
+
+function calcLineAndColumn(source, index) {
+  const lines = source
+    .substring(0, index)
+    .split(newLines)
+  const line = lines.length;
+  const column = lines.pop().length + 1;
+
+  return {
+    column,
+    line
+  };
+}
+
+function adjustForLineAndColumn(fullSource, location) {
+  const {column, line} = calcLineAndColumn(fullSource, location.index);
+  return Object.assign({}, location, {
+    line,
+    column,
+    // prepend whitespace for scripts that do not start on the first column
+    source: generateWhitespace(column) + location.source
+  });
+}
+
+function parseScriptTags(source, parser) {
+  const scripts = parseScripts(
+    getCandidateScriptLocations(source),
+    parser
+  ).filter(
+    types.isFile
+  ).reduce((main, script) => {
+    return {
+      statements: main.statements.concat(script.program.body),
+      comments: main.comments.concat(script.comments),
+      tokens: main.tokens.concat(script.tokens)
+    };
+  }, {
+    statements: [],
+    comments: [],
+    tokens: []
+  });
+
+  const program = types.program(scripts.statements);
+  const file = types.file(
+    program,
+    scripts.comments,
+    scripts.tokens
+  );
+
+  const end = calcLineAndColumn(source, source.length);
+  file.start = program.start = 0;
+  file.end = program.end = source.length;
+  file.loc = program.loc = {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end
+  }
+
+  return file;
+}
+
+export default parseScriptTags;
+export {
+  generateWhitespace,
+  getCandidateScriptLocations,
+  parseScripts,
+  parseScriptTags
+};

--- a/dist/package.json
+++ b/dist/package.json
@@ -7,7 +7,9 @@
     "outdir": "dist"
   },
   "jest": {
-    "modulePathIgnorePatterns": ["/dist/"]
+    "modulePathIgnorePatterns": [
+      "/dist/"
+    ]
   },
   "scripts": {
     "build:babel": "babel index.js -d $npm_package_config_outdir",
@@ -36,6 +38,7 @@
   },
   "dependencies": {
     "babel-types": "^6.24.1",
-    "babylon": "^6.17.0"
+    "babylon": "^6.17.0",
+    "parse5": "^3.0.3"
   }
 }

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-script-tags",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Parses the contents of each inline <script> tag to produce a single AST",
   "main": "index.js",
   "config": {

--- a/index.js
+++ b/index.js
@@ -1,68 +1,14 @@
-const babylon = require("babylon");
-const parse5 = require("parse5");
-const types = require("babel-types");
 
-const startScript = /<script[^>]*>/im;
-const endScript = /<\/script\s*>/im;
-// https://stackoverflow.com/questions/5034781/js-regex-to-split-by-line#comment5633979_5035005
-const newLines = /\r\n|[\n\v\f\r\x85\u2028\u2029]/;
+import * as types from "babel-types";
+import * as babylon from "babylon";
 
-function getType (tag) {
-  const fragment = parse5.parseFragment(tag);
+import {
+  generateWhitespace,
+  getCandidateScriptLocations,
+  parseScripts as customParseScripts,
+  parseScriptTags as customParseScriptTags
+} from "./customParse.js";
 
-  if (fragment) {
-    const script = fragment.childNodes
-      .filter(node => node.tagName === "script")
-      .pop();
-
-    if (script) {
-      const type = script.attrs
-        .filter(attr => attr.name === "type")
-        .map(attr => attr.value)
-        .pop();
-
-      return type ? type.toLowerCase() : null;
-    }
-  }
-
-  return null;
-}
-
-function getCandidateScriptLocations(source, index) {
-  const i = index || 0;
-  const str = source.substring(i);
-
-  const startMatch = startScript.exec(str);
-  if (startMatch) {
-    const startsAt = startMatch.index + startMatch[0].length;
-    const afterStart = str.substring(startsAt);
-    const endMatch = endScript.exec(afterStart);
-    if (endMatch) {
-      const locLength = endMatch.index;
-      const locIndex = i + startsAt;
-      const endIndex = locIndex + locLength + endMatch[0].length;
-
-      // extract the complete tag (incl start and end tags and content). if the
-      // type is invalid (= not JS), skip this tag and continue
-      const tag = source.substring(i + startMatch.index, endIndex);
-      const type = getType(tag);
-      if (type && (type !== "javascript" && type !== "text/javascript")) {
-        return getCandidateScriptLocations(source, endIndex);
-      }
-
-      return [
-        adjustForLineAndColumn(source, {
-          index: locIndex,
-          length: locLength,
-          source: source.substring(locIndex, locIndex + locLength)
-        }),
-        ...getCandidateScriptLocations(source, endIndex)
-      ];
-    }
-  }
-
-  return [];
-}
 
 function parseScript({source, line}) {
   // remove empty or only whitespace scripts
@@ -80,74 +26,8 @@ function parseScript({source, line}) {
   }
 }
 
-function parseScripts(locations, parser = parseScript) {
-  return locations.map(parser);
-}
-
-function generateWhitespace(length) {
-  return Array.from(new Array(length + 1)).join(" ");
-}
-
-function calcLineAndColumn(source, index) {
-  const lines = source
-    .substring(0, index)
-    .split(newLines)
-  const line = lines.length;
-  const column = lines.pop().length + 1;
-
-  return {
-    column,
-    line
-  };
-}
-
-function adjustForLineAndColumn(fullSource, location) {
-  const {column, line} = calcLineAndColumn(fullSource, location.index);
-  return Object.assign({}, location, {
-    line,
-    column,
-    // prepend whitespace for scripts that do not start on the first column
-    source: generateWhitespace(column) + location.source
-  });
-}
-
-function parseScriptTags(source, parser) {
-  const scripts = parseScripts(
-    getCandidateScriptLocations(source),
-    parser
-  ).filter(
-    types.isFile
-  ).reduce((main, script) => {
-    return {
-      statements: main.statements.concat(script.program.body),
-      comments: main.comments.concat(script.comments),
-      tokens: main.tokens.concat(script.tokens)
-    };
-  }, {
-    statements: [],
-    comments: [],
-    tokens: []
-  });
-
-  const program = types.program(scripts.statements);
-  const file = types.file(
-    program,
-    scripts.comments,
-    scripts.tokens
-  );
-
-  const end = calcLineAndColumn(source, source.length);
-  file.start = program.start = 0;
-  file.end = program.end = source.length;
-  file.loc = program.loc = {
-    start: {
-      line: 1,
-      column: 0
-    },
-    end
-  }
-
-  return file;
+function parseScripts (locations, parser = parseScript) {
+  return customParseScripts(locations, parser);
 }
 
 function extractScriptTags(source) {
@@ -166,6 +46,11 @@ function extractScriptTags(source) {
     types.isFile
   );
 }
+
+function parseScriptTags (source, parser = parseScript) {
+  return customParseScriptTags(source, parser);
+}
+
 
 export default parseScriptTags;
 export {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-script-tags",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Parses the contents of each inline <script> tag to produce a single AST",
   "main": "index.js",
   "config": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "babel-types": "^6.24.1",
-    "babylon": "^6.17.0",
-    "parse5": "^3.0.3"
+    "babylon": "^6.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     ]
   },
   "scripts": {
-    "build:babel": "babel index.js -d $npm_package_config_outdir",
+    "build:babel": "babel *.js -d $npm_package_config_outdir",
     "build:package": "cp package.json $npm_package_config_outdir/package.json",
     "build": "npm run build:babel && npm run build:package",
     "release:git": "./bin/git.sh",

--- a/parseScriptFragment.js
+++ b/parseScriptFragment.js
@@ -1,0 +1,151 @@
+
+const alphanum = /[a-z0-9\-]/i;
+
+function parseToken (str, start) {
+  let i = start;
+  while (i < str.length && alphanum.test(str.charAt(i++))) {
+    continue;
+  }
+  
+  if (i !== start) {
+    return {
+      token: str.substring(start, i - 1),
+      index: i
+    };
+  }
+  
+  return null;
+}
+
+function parseAttributes (str, start) {
+  let i = start;
+  const attributes = {};
+  let attribute = null;
+
+  while (i < str.length) {
+    const c = str.charAt(i);
+    
+    if (attribute === null && c == ">") {
+      break;
+    } else if (attribute === null && alphanum.test(c)) {
+      attribute = {
+        name: null,
+        value: true,
+        bool: true,
+        terminator: null
+      };
+
+      const attributeNameNode = parseToken(str, i);
+      if (attributeNameNode) {
+        attribute.name = attributeNameNode.token;
+        i = attributeNameNode.index - 2;
+      }
+    } else if (attribute !== null) {
+      if (c === "=") {
+        // once we've started an attribute, look for = to indicate
+        // it's a non-boolean attribute
+        attribute.bool = false;
+        if (attribute.value === true) {
+          attribute.value = "";
+        }
+      } else if (
+        !attribute.bool &&
+        attribute.terminator === null &&
+        (c === '"' || c === "'")
+      ) {
+        // once we've determined it's non-boolean, look for a
+        // value terminator (", ')
+        attribute.terminator = c;
+      } else if (attribute.terminator) {
+        if (c === attribute.terminator) {
+          // if we had a terminator and found another, we've
+          // reach the end of the attribute
+          attributes[attribute.name] = attribute.value;
+          attribute = null;
+        } else {
+          // otherwise, append the character to the attribute value
+          attribute.value += c;
+          
+          // check for an escaped terminator and push it as well
+          // to avoid terminating prematurely
+          if (c === "\\") {
+            const next = str.charAt(i + 1);
+            if (next === attribute.terminator) {
+              attribute.value += next;
+              i += 1;
+            }
+          }
+        }
+      } else if (!/\s/.test(c)) {
+        // if we've hit a non-space character and aren't processing a value,
+        // we're starting a new attribute so push the attribute and clear the
+        // local variable
+        attributes[attribute.name] = attribute.value;
+        attribute = null;
+        
+        // move the cursor back to re-find the start of the attribute
+        i -= 1;
+      }
+    }
+    
+    i++;
+  }
+  
+  if (i !== start) {
+    return {
+      attributes,
+      index: i
+    };
+  }
+  
+  return null;
+}
+
+function parseFragment (str, start = 0) {
+  let tag = null;
+  let open = false;
+  let attributes = {};
+  
+  let i = start;
+  while (i < str.length) {
+    let c = str.charAt(i++);
+    
+    if (!open && !tag && c === "<") {
+      // Open Start Tag
+      open = true;
+
+      const tagNode = parseToken(str, i);
+      if (!tagNode) {
+        return null;
+      }
+      
+      i = tagNode.index - 1;
+      tag = tagNode.token;
+    } else if (open && c === ">") {
+      // Close Start Tag
+      break;
+    } else if (open) {
+      // Attributes
+      const attributeNode = parseAttributes(str, i - 1);
+      
+      if (attributeNode) {
+        i = attributeNode.index;
+        attributes = attributeNode.attributes || attributes;
+      }
+    }
+  }
+  
+  if (tag) {
+    return {
+      tag,
+      attributes
+    };
+  }
+
+  return null;
+}
+
+export default parseFragment;
+export {
+  parseFragment
+};


### PR DESCRIPTION
I've written up a much simpler tag parser that seems work with the use cases of this module. It passes all current tests without modification.